### PR TITLE
Update package.json for lwip dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/Vaidas737/express-thumbnail/issues"
   },
   "dependencies": {
-    "lwip": "0.0.8",
+    "lwip": "0.0.9",
     "mkdirp": "~0.5.*"
   },
   "devDependencies": {


### PR DESCRIPTION
lwip was recently updated to version 0.0.9 to fix issues with installing it on node v6 systems. Currently express-thumbnail fails to install due to the dependency on 0.0.9.
